### PR TITLE
Remove underscores from generated schemas to match generic-aeson

### DIFF
--- a/src/Data/JSON/Schema/Generic.hs
+++ b/src/Data/JSON/Schema/Generic.hs
@@ -14,7 +14,6 @@
 module Data.JSON.Schema.Generic (gSchema) where
 
 import Control.Applicative hiding (empty, (<|>))
-import Data.Char
 import Data.JSON.Schema.Combinators
 import Data.JSON.Schema.Types
 import Data.Maybe
@@ -22,6 +21,7 @@ import Data.Proxy
 import Data.Text (Text)
 import GHC.Generics
 import Generics.Deriving.ConNames
+import Generics.Generic.Aeson (formatLabel)
 import Generics.Generic.IsEnum
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.Text        as T
@@ -64,7 +64,7 @@ pv :: Proxy a -> a
 pv _ = undefined
 
 toConstant :: Text -> Schema
-toConstant = Constant . Aeson.String . firstLetterToLower
+toConstant = Constant . Aeson.String . formatLabel
 
 instance (GJSONSCHEMA f, GJSONSCHEMA g) => GJSONSCHEMA (f :*: g) where
   gSchema' enm names p = gSchema' enm names (gFst <$> p) `merge` gSchema' enm names (gSnd <$> p)
@@ -74,17 +74,12 @@ instance (Constructor c, GJSONSCHEMA f) => GJSONSCHEMA (M1 C c f) where
   gSchema' enm names = wrap . gSchema' enm names . fmap unM1
     where
       wrap = if multipleConstructors names
-             then field (firstLetterToLower $ conNameT (undefined :: M1 C c f p)) True
+             then field (conNameT (undefined :: M1 C c f p)) True
              else id
 
 instance GJSONSCHEMA f => GJSONSCHEMA (M1 D c f) where
   gSchema' True names p | multipleConstructors names = const (Choice . fmap toConstant $ names) $ p
   gSchema' enm names p = gSchema' enm names . fmap unM1 $ p
-
-firstLetterToLower :: Text -> Text
-firstLetterToLower m = case T.uncons m of
-  Nothing      -> ""
-  Just (l, ls) -> T.cons (toLower l) ls
 
 instance (Selector c, JSONSchema a) => GJSONSCHEMA (M1 S c (K1 i (Maybe a))) where
   gSchema' _ _ = field (selNameT (undefined :: M1 S c f p)) False . schema . fmap (fromJust . unK1 . unM1)
@@ -96,15 +91,15 @@ instance Selector c => GJSONSCHEMA (M1 S c (K1 i (Maybe String))) where
 instance (Selector c, GJSONSCHEMA f) => GJSONSCHEMA (M1 S c f) where
   gSchema' enm names = wrap . gSchema' enm names . fmap unM1
     where
-      wrap = case (T.pack . selName) (undefined :: M1 S c f p) of
+      wrap = case (formatLabel . T.pack . selName) (undefined :: M1 S c f p) of
         "" -> id
         s -> field s True
 
 conNameT :: forall c (t :: * -> (* -> *) -> * -> *) (f :: * -> *) a. Constructor c => t c f a -> Text
-conNameT x = T.pack . conName $ x
+conNameT x = formatLabel . T.pack . conName $ x
 
 selNameT :: forall s (t :: * -> (* -> *) -> * -> *) (f :: * -> *) a. Selector s => t s f a -> Text
-selNameT x = T.pack . selName $ x
+selNameT x = formatLabel . T.pack . selName $ x
 
 multipleConstructors :: [Text] -> Bool
 multipleConstructors = (> 1) . length

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -11,7 +11,6 @@ import Data.Aeson hiding (Result)
 import Data.Aeson.Parser
 import Data.Attoparsec.Lazy
 import Data.ByteString.Lazy (ByteString)
-import Data.JSON.Schema (JSONSchema (..), gSchema, Field (..))
 import Data.List (intersperse)
 import Data.Proxy
 import GHC.Generics (Generic)
@@ -20,7 +19,9 @@ import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.TH
 import qualified Data.Aeson.Types as A
+
 import qualified Data.JSON.Schema as S
+import Data.JSON.Schema (JSONSchema (..), gSchema, Field (..))
 
 data SingleCons = SingleCons deriving (Generic, Show, Eq)
 instance ToJSON   SingleCons where toJSON    = gtoJson
@@ -191,7 +192,7 @@ instance JSONSchema W where schema = gSchema
 case_recordWithUnderscoredFields = do
   eq (unsafeParse "{\"underscore1\":1,\"underscore2\":2}",Right (W {underscore1_ = 1, _underscore2 = 2}))
      (toJSON (W 1 2), encDec (W 1 2))
-  eq (S.Object [Field {key = "underscore1_", required = True, content = S.Number S.unbounded},Field {key = "_underscore2", required = True, content = S.Number S.unbounded}])
+  eq (S.Object [Field {key = "underscore1", required = True, content = S.Number S.unbounded},Field {key = "underscore2", required = True, content = S.Number S.unbounded}])
      (schema (Proxy :: Proxy W))
 
 -- Helpers


### PR DESCRIPTION
Depends on exposing `formatLabel` from generic-aeson, so I'll leave this here for now.
