### PR TITLE
Change Number bounds from `Int` to `Scientific`.

### DIFF
--- a/src/Data/JSON/Schema/Types.hs
+++ b/src/Data/JSON/Schema/Types.hs
@@ -17,6 +17,7 @@ module Data.JSON.Schema.Types
 import Data.Fixed
 import Data.Maybe
 import Data.Proxy
+import Data.Scientific
 import Data.String
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
@@ -55,8 +56,8 @@ data Schema =
 
 -- | A type for bounds on number domains. Use Nothing when no lower or upper bound makes sense
 data Bound = Bound
-  { lower :: Maybe Int
-  , upper :: Maybe Int
+  { lower :: Maybe Scientific
+  , upper :: Maybe Scientific
   } deriving (Eq, Show)
 
 -- | A type for bounds on lengths for strings and arrays. Use Nothing when no lower or upper bound makes sense

--- a/src/Data/JSON/Schema/Validate.hs
+++ b/src/Data/JSON/Schema/Validate.hs
@@ -126,13 +126,13 @@ unique vs = do
 
 inLower :: S.Bound -> Scientific -> M ()
 inLower b v =
-  if (maybe True ((<= v) . fromIntegral) . S.lower $ b)
+  if (maybe True (<= v) . S.lower $ b)
     then ok
     else err (BoundError b v)
 
 inUpper :: S.Bound -> Scientific -> M ()
 inUpper b v =
-  if (maybe True ((>= v) . fromIntegral) . S.upper $ b)
+  if (maybe True (>= v) . S.upper $ b)
     then ok
     else err (BoundError b v)
 


### PR DESCRIPTION
This allows validation on all values regardless of size of `maxBound`.

If this is merged, the code from PR #17 would change with sane bounds.
